### PR TITLE
Fix for 4 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "main": "./index.js",
   "dependencies": {
-    "request": "2.27.x",
+    "request": "2.74.0",
     "underscore": "1.8.x",
     "mime": "1.3.x"
   },


### PR DESCRIPTION
kaiseki currently has  vulnerable dependency, introducing 4 different types of known vulnerabilities.

* [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
* [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
* [Denial of Service (Event Loop Blocking) vulnerability](https://snyk.io/vuln/npm:qs:20140806-1) in the `qs` dependency.
* [Denial of Service (Memory Exhaustion)](https://snyk.io/vuln/npm:qs:20140806) in the `qs` dependency.
You can see [Snyk test report](https://snyk.io/test/github/shiki/kaiseki) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and does not pull in any other vulnerable dependencies.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Stay Secure,
The Snyk Community.